### PR TITLE
Make the *wiki-summary* buffer easily dismissable with q.

### DIFF
--- a/wiki-summary.el
+++ b/wiki-summary.el
@@ -60,7 +60,7 @@
       (fill-paragraph)
       (goto-char (point-min))
       (text-mode)
-      (read-only-mode))
+      (view-mode))
     (pop-to-buffer buf)))
 
 ;;;###autoload

--- a/wiki-summary.el
+++ b/wiki-summary.el
@@ -61,7 +61,7 @@
       (goto-char (point-min))
       (text-mode)
       (read-only-mode))
-    (display-buffer buf)))
+    (pop-to-buffer buf)))
 
 ;;;###autoload
 (defun wiki-summary (s)


### PR DESCRIPTION
Often after reading the Wikipedia summary I want to get rid of it. This change makes it so you the summary window gets the focus, which means you can easily dismiss it with `q`.