### PR TITLE
fill whole buffer rather than paragraph

### DIFF
--- a/wiki-summary.el
+++ b/wiki-summary.el
@@ -66,7 +66,7 @@
   (let ((buf (generate-new-buffer "*wiki-summary*")))
     (with-current-buffer buf
       (princ summary buf)
-      (fill-paragraph)
+      (fill-region (point-min) (point-max))
       (goto-char (point-min))
       (text-mode)
       (view-mode))


### PR DESCRIPTION
Formatting the summary did not always work as expected. I suspect due to extra blank lines.
This way the whole buffer is formatted.